### PR TITLE
Fix capitialization on class and variable names to better match the ""C# standard""

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1,16 +1,7 @@
-﻿using Splotch.Loader.ModLoader;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using TMPro;
 using UnityEngine;
-using YamlDotNet;
 using YamlDotNet.Core;
-using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -18,14 +9,14 @@ namespace Splotch
 {
     public static class Config
     {
-        internal struct SplotchConfig
+        internal struct SplotchConfigStruct
         {
             public bool splotchEnabled;
             public bool consoleEnabled;
             public bool verboseLoggingEnabled;
         }
 
-        internal static SplotchConfig LoadedSplotchConfig = new SplotchConfig
+        internal static SplotchConfigStruct LoadedSplotchConfig = new SplotchConfigStruct
         {
             splotchEnabled = true,
             consoleEnabled = true,
@@ -34,7 +25,7 @@ namespace Splotch
 
         internal struct SplotchConfigContainer
         {
-            public SplotchConfig splotchConfig;
+            public SplotchConfigStruct splotchConfig;
         }
 
         internal static void CreateConfigAndLoadSplotchConfig() // This basically just creates the config, and if it already exists, we return back
@@ -56,11 +47,11 @@ namespace Splotch
 
                 SplotchConfigContainer cont = new SplotchConfigContainer
                 {
-                    splotchConfig = new SplotchConfig
-                    { 
+                    splotchConfig = new SplotchConfigStruct
+                    {
                         splotchEnabled = true,
                         consoleEnabled = true,
-                        verboseLoggingEnabled = true,
+                        verboseLoggingEnabled = false,
                     }
                 };
 

--- a/Loader.cs
+++ b/Loader.cs
@@ -27,7 +27,7 @@ namespace Splotch.Loader
 
             enteredScene = true;
             Patcher.DoPatching();
-            ModLoader.ModLoader.loadMods();
+            ModLoader.ModLoader.LoadMods();
         }
 
         /// <summary>

--- a/Logger.cs
+++ b/Logger.cs
@@ -10,7 +10,7 @@ public static class Logger
     /// what class A() is from
     /// </summary>
     /// <returns>The class that called your function</returns>
-    private static string getCallingClass()
+    private static string GetCallingClass()
     {
         // Basically its meant for errors but it also logs every function that is called!
         StackTrace stackTrace = new StackTrace();
@@ -73,7 +73,7 @@ public static class Logger
     /// </summary>
     public static void Log(string message)
     {
-        string formattedString = $"[INFO    : {getCallingClass()}] {message}";
+        string formattedString = $"[INFO    : {GetCallingClass()}] {message}";
 
         Console.ForegroundColor = ConsoleColor.Gray;
 
@@ -86,7 +86,7 @@ public static class Logger
     /// </summary>
     public static void Warning(string message)
     {
-        string formattedString = $"[WARNING : {getCallingClass()}] {message}";
+        string formattedString = $"[WARNING : {GetCallingClass()}] {message}";
 
         Console.ForegroundColor = ConsoleColor.Yellow;
 
@@ -101,7 +101,7 @@ public static class Logger
     /// </summary>
     public static void Error(string message)
     {
-        string formattedString = $"[ERROR   : {getCallingClass()}] {message}";
+        string formattedString = $"[ERROR   : {GetCallingClass()}] {message}";
 
         Console.ForegroundColor = ConsoleColor.Red;
 
@@ -122,7 +122,7 @@ public static class Logger
         {
             return;
         }
-        string formattedString = $"[DEBUG   : {getCallingClass()}] {message}";
+        string formattedString = $"[DEBUG   : {GetCallingClass()}] {message}";
 
         Console.ForegroundColor = ConsoleColor.White;
 

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -20,7 +20,7 @@ namespace Splotch.Loader.ModLoader
         /// <summary>
         /// Called by the <c>Loader</c>, loads all detected mods and logs any issues encountered during loading.
         /// </summary>
-        internal static void loadMods()
+        internal static void LoadMods()
         {
             Logger.Log("Starting to load mods...");
             int modCountLoaded = 0;
@@ -44,7 +44,7 @@ namespace Splotch.Loader.ModLoader
                             data = deserializedData.ToModInfo();
                         }
 
-                        bool loadSuccess = data.loadMod(modFolderPath);
+                        bool loadSuccess = data.LoadMod(modFolderPath);
                         if (loadSuccess)
                         {
                             Logger.Log($"{data} loaded");
@@ -80,15 +80,15 @@ namespace Splotch.Loader.ModLoader
     /// </summary>
     class DeserializedModInfo
     {
-        public ModEntrypointData entrypoint { get; set; }
-        public ModAttributesData attributes { get; set; }
+        public ModEntrypointData Entrypoint { get; set; }
+        public ModAttributesData Attributes { get; set; }
         /// <summary>
         /// An internal class for the <c>entrypoint</c> section of the <c>modinfo.yaml</c> file.
         /// </summary>
         public class ModEntrypointData
         {
-            public string dll { get; set; }
-            public string className { get; set; }
+            public string DLL { get; set; }
+            public string ClassName { get; set; }
         }
 
         /// <summary>
@@ -96,12 +96,12 @@ namespace Splotch.Loader.ModLoader
         /// </summary>
         public class ModAttributesData
         {
-            public string id { get; set; }
-            public string name { get; set; }
+            public string ID { get; set; }
+            public string Name { get; set; }
 
-            public string description { get; set; } = "";
-            public string version { get; set; } = "1.0";
-            public string[] authors { get; set; } = { };
+            public string Description { get; set; } = "";
+            public string Version { get; set; } = "1.0";
+            public string[] Authors { get; set; } = { };
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Splotch.Loader.ModLoader
         /// <returns>The <c>ModInfo</c> representation of the class</returns>
         internal ModInfo ToModInfo()
         {
-            return new ModInfo(entrypoint.dll, entrypoint.className, attributes.id, attributes.name, attributes.description, attributes.version, attributes.authors);
+            return new ModInfo(Entrypoint.DLL, Entrypoint.ClassName, Attributes.ID, Attributes.Name, Attributes.Description, Attributes.Version, Attributes.Authors);
         }
     }
 
@@ -144,7 +144,7 @@ namespace Splotch.Loader.ModLoader
         /// </summary>
         /// <param name="modFolder">The folder the mod is contained in.</param>
         /// <returns><c>true</c> if the loading was successful and <c>false</c> if there was an error.</returns>
-        internal bool loadMod(string modFolder)
+        internal bool LoadMod(string modFolder)
         {
             try
             {

--- a/SplotchMod.cs
+++ b/SplotchMod.cs
@@ -8,13 +8,13 @@ namespace Splotch
     /// </summary>
     public abstract class SplotchMod
     {
-        public ModInfo modInfo { get; internal set; }
-        public Harmony harmony { get; internal set; }
+        public ModInfo ModInfo { get; internal set; }
+        public Harmony Harmony { get; internal set; }
 
         internal void Setup(ModInfo modInfo)
         {
-            this.modInfo = modInfo;
-            harmony = new Harmony(modInfo.id);
+            this.ModInfo = modInfo;
+            Harmony = new Harmony(modInfo.id);
 
         }
         /// <summary>


### PR DESCRIPTION
I also cleaned up some using statements on config.cs